### PR TITLE
Added requirements file for binder, as well as link to binder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+.tox
+*.swp

--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@ This repository contains materials and information about
 Astro Hack Week 2019.
 
 ### Tutorials
+
 * Monday: Data Visualization
 * Tuesday: Software Development and Querying Surveys + Data Management
 * Wednesday: Machine Learning, Bayesian Inference
 * Thursday: Machine Learning, Bayesian Inference
+
+### Binder
+
+If you want to open the notebooks in this repository on binder, you can use
+the link below:
+
+[![Binder](http://mybinder.org/badge_logo.svg)](http://mybinder.org/v2/gh/AstroHackWeek/AstroHackWeek2019/master)
 
 ### Instructions for Pull Requests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+numpy
+matplotlib
+astropy
+seaborn
+altair
+vega
+pywwt
+mpl-scatter-density
+notebook


### PR DESCRIPTION
This PR makes it possible for participants to open the visualization tutorial notebook (as well as any other future notebooks) with binder. You can preview this at http://mybinder.org/v2/gh/astrofrog/AstroHackWeek2019/binder