### PR TITLE
Switch to more conventional matplotlib import

### DIFF
--- a/day3_bayes/ahw_complete.ipynb
+++ b/day3_bayes/ahw_complete.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "import numpy as np\n",
     "import numpy.random as npr\n",
-    "import matplotlib.pyplot as mp\n",
+    "import matplotlib.pyplot as plt\n",
     "import scipy.stats as sps\n",
     "%matplotlib inline"
    ]
@@ -119,7 +119,7 @@
     "\n",
     "# plot versus expectations\n",
     "print('parameter means & standard deviations')\n",
-    "fig, axes = mp.subplots(1, 2, figsize=(12, 5))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
     "for i in range(2):\n",
     "    print('*', par_names[i])\n",
     "    print('  reals:  ', np.mean(pars[:, i]), np.std(pars[:, i]))\n",
@@ -155,7 +155,7 @@
     "noise = y - (pars[0] * x + pars[1])\n",
     "\n",
     "# plot noise histogram versus expectation\n",
-    "fig, axes = mp.subplots(1, 2, figsize=(12, 5))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
     "axes[0].plot(x, y)\n",
     "axes[0].plot(x, pars[0] * x + pars[1])\n",
     "axes[0].set_xlabel('$x$')\n",
@@ -248,7 +248,7 @@
     "post_intcpt = np.sum(post, axis=0)\n",
     "\n",
     "# plot joint and marginal posteriors\n",
-    "fig, axes = mp.subplots(2, 2, figsize=(8, 8))\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(8, 8))\n",
     "levels = np.array([0.011109, 0.13533528, 0.60653066]) * np.max(post)\n",
     "axes[0, 0].plot(slope_grid, post_slope, color='k')\n",
     "axes[1, 1].plot(intcpt_grid, post_intcpt, color='k')\n",
@@ -373,7 +373,7 @@
     "\n",
     "# plot versus expectations\n",
     "print('parameter means & standard deviations')\n",
-    "fig, axes = mp.subplots(1, 3, figsize=(16, 5))\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(16, 5))\n",
     "for i in range(3):\n",
     "    print('*', par_names_nv[i])\n",
     "    print('  reals:  ', np.mean(pars[:, i]), np.std(pars[:, i]))\n",
@@ -412,7 +412,7 @@
     "noise = y - (pars[0] * x + pars[1])\n",
     "\n",
     "# plot noise histogram versus expectation\n",
-    "fig, axes = mp.subplots(1, 2, figsize=(12, 5))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
     "axes[0].plot(x, y)\n",
     "axes[0].plot(x, pars[0] * x + pars[1])\n",
     "axes[0].set_xlabel('$x$')\n",
@@ -556,7 +556,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axes = mp.subplots(1, 2, figsize=(12, 5))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
     "axes[0].plot(samples[:, 0], samples[:, 1])\n",
     "axes[0].set_xlabel(par_names_nv[0])\n",
     "axes[0].set_ylabel(par_names_nv[1])\n",
@@ -602,7 +602,7 @@
    "source": [
     "n_samples = 10000\n",
     "mult = np.array([0.01, 1000.0])\n",
-    "fig, axes = mp.subplots(1, 2, figsize=(12, 5))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
     "for i in range(2):\n",
     "    prop_cov_i = prop_cov * mult[i]\n",
     "    npr.seed(1234)\n",
@@ -759,9 +759,9 @@
    "source": [
     "pars_nvx, y_nvx = simulator_nvx(mu_x, sig_x, sig_noise_x, mu_slope, sig_slope, mu_intcpt, sig_intcpt, \\\n",
     "                                shape_var_noise, scale_var_noise)\n",
-    "mp.errorbar(y_nvx[0: n_x], y_nvx[n_x:], yerr=np.sqrt(pars_nvx[n_x + 2]), xerr=sig_noise_x)\n",
-    "mp.xlabel('$x$')\n",
-    "mp.ylabel('$y$')"
+    "plt.errorbar(y_nvx[0: n_x], y_nvx[n_x:], yerr=np.sqrt(pars_nvx[n_x + 2]), xerr=sig_noise_x)\n",
+    "plt.xlabel('$x$')\n",
+    "plt.ylabel('$y$')"
    ]
   },
   {
@@ -1045,10 +1045,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mp.plot(g_samples[n_x + 2, :])\n",
-    "mp.axhline(pars_nvx[n_x + 2], color='C1')\n",
-    "mp.xlabel('sample')\n",
-    "mp.ylabel(par_names_nv_co[2])\n",
+    "plt.plot(g_samples[n_x + 2, :])\n",
+    "plt.axhline(pars_nvx[n_x + 2], color='C1')\n",
+    "plt.xlabel('sample')\n",
+    "plt.ylabel(par_names_nv_co[2])\n",
     "print('Truth {:6.4f}; inferred {:6.4f} +/- {:6.4f}'.format(pars_nvx[n_x + 2], \\\n",
     "                                                           np.mean(g_samples[n_x + 2, :]), \\\n",
     "                                                           np.std(g_samples[n_x + 2, :])))"

--- a/day3_bayes/ahw_incomplete.ipynb
+++ b/day3_bayes/ahw_incomplete.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "import numpy as np\n",
     "import numpy.random as npr\n",
-    "import matplotlib.pyplot as mp\n",
+    "import matplotlib.pyplot as plt\n",
     "import scipy.stats as sps\n",
     "%matplotlib inline"
    ]
@@ -119,7 +119,7 @@
     "\n",
     "# plot versus expectations\n",
     "print('parameter means & standard deviations')\n",
-    "fig, axes = mp.subplots(1, 2, figsize=(12, 5))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
     "for i in range(2):\n",
     "    print('*', par_names[i])\n",
     "    print('  reals:  ', np.mean(pars[:, i]), np.std(pars[:, i]))\n",
@@ -155,7 +155,7 @@
     "noise = y - (pars[0] * x + pars[1])\n",
     "\n",
     "# plot noise histogram versus expectation\n",
-    "fig, axes = mp.subplots(1, 2, figsize=(12, 5))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
     "axes[0].plot(x, y)\n",
     "axes[0].plot(x, pars[0] * x + pars[1])\n",
     "axes[0].set_xlabel('$x$')\n",
@@ -244,7 +244,7 @@
     "post_intcpt = # ???\n",
     "\n",
     "# plot joint and marginal posteriors\n",
-    "fig, axes = mp.subplots(2, 2, figsize=(8, 8))\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(8, 8))\n",
     "levels = np.array([0.011109, 0.13533528, 0.60653066]) * np.max(post)\n",
     "axes[0, 0].plot(slope_grid, post_slope, color='k')\n",
     "axes[1, 1].plot(intcpt_grid, post_intcpt, color='k')\n",
@@ -369,7 +369,7 @@
     "\n",
     "# plot versus expectations\n",
     "print('parameter means & standard deviations')\n",
-    "fig, axes = mp.subplots(1, 3, figsize=(16, 5))\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(16, 5))\n",
     "for i in range(3):\n",
     "    print('*', par_names_nv[i])\n",
     "    print('  reals:  ', np.mean(pars[:, i]), np.std(pars[:, i]))\n",
@@ -408,7 +408,7 @@
     "noise = y - (pars[0] * x + pars[1])\n",
     "\n",
     "# plot noise histogram versus expectation\n",
-    "fig, axes = mp.subplots(1, 2, figsize=(12, 5))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
     "axes[0].plot(x, y)\n",
     "axes[0].plot(x, pars[0] * x + pars[1])\n",
     "axes[0].set_xlabel('$x$')\n",
@@ -546,7 +546,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axes = mp.subplots(1, 2, figsize=(12, 5))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
     "axes[0].plot(samples[:, 0], samples[:, 1])\n",
     "axes[0].set_xlabel(par_names_nv[0])\n",
     "axes[0].set_ylabel(par_names_nv[1])\n",
@@ -592,7 +592,7 @@
    "source": [
     "n_samples = 10000\n",
     "mult = np.array([0.01, 1000.0])\n",
-    "fig, axes = mp.subplots(1, 2, figsize=(12, 5))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
     "for i in range(2):\n",
     "    prop_cov_i = prop_cov * mult[i]\n",
     "    npr.seed(1234)\n",
@@ -748,9 +748,9 @@
    "source": [
     "pars_nvx, y_nvx = simulator_nvx(mu_x, sig_x, sig_noise_x, mu_slope, sig_slope, mu_intcpt, sig_intcpt, \\\n",
     "                                shape_var_noise, scale_var_noise)\n",
-    "mp.errorbar(y_nvx[0: n_x], y_nvx[n_x:], yerr=np.sqrt(pars_nvx[n_x + 2]), xerr=sig_noise_x)\n",
-    "mp.xlabel('$x$')\n",
-    "mp.ylabel('$y$')"
+    "plt.errorbar(y_nvx[0: n_x], y_nvx[n_x:], yerr=np.sqrt(pars_nvx[n_x + 2]), xerr=sig_noise_x)\n",
+    "plt.xlabel('$x$')\n",
+    "plt.ylabel('$y$')"
    ]
   },
   {
@@ -1026,10 +1026,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mp.plot(g_samples[n_x + 2, :])\n",
-    "mp.axhline(pars_nvx[n_x + 2], color='C1')\n",
-    "mp.xlabel('sample')\n",
-    "mp.ylabel(par_names_nv_co[2])\n",
+    "plt.plot(g_samples[n_x + 2, :])\n",
+    "plt.axhline(pars_nvx[n_x + 2], color='C1')\n",
+    "plt.xlabel('sample')\n",
+    "plt.ylabel(par_names_nv_co[2])\n",
     "print('Truth {:6.4f}; inferred {:6.4f} +/- {:6.4f}'.format(pars_nvx[n_x + 2], \\\n",
     "                                                           np.mean(g_samples[n_x + 2, :]), \\\n",
     "                                                           np.std(g_samples[n_x + 2, :])))"

--- a/day3_bayes/ahw_intro_complete.ipynb
+++ b/day3_bayes/ahw_intro_complete.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "import numpy as np\n",
     "import numpy.random as npr\n",
-    "import matplotlib.pyplot as mp\n",
+    "import matplotlib.pyplot as plt\n",
     "import scipy.stats as sps\n",
     "%matplotlib inline"
    ]
@@ -58,9 +58,9 @@
     "    return theta ** k * (1.0 - theta) ** (n - k)\n",
     "\n",
     "theta_grid = np.linspace(0.0, 1.0, 100)\n",
-    "mp.plot(theta_grid, post_binomial(10, 3, theta_grid))\n",
-    "mp.xlabel(r'$\\theta$')\n",
-    "mp.ylabel(r'${\\rm P}(\\theta)$')"
+    "plt.plot(theta_grid, post_binomial(10, 3, theta_grid))\n",
+    "plt.xlabel(r'$\\theta$')\n",
+    "plt.ylabel(r'${\\rm P}(\\theta)$')"
    ]
   },
   {
@@ -84,9 +84,9 @@
     "\n",
     "counts = np.array([4, 0, 3, 2, 4, 2, 3])\n",
     "rate_grid = np.linspace(0.0, 10.0, 100)\n",
-    "mp.plot(rate_grid, post_poisson(counts, rate_grid))\n",
-    "mp.xlabel(r'$\\lambda$')\n",
-    "mp.ylabel(r'${\\rm P}(\\lambda)$')"
+    "plt.plot(rate_grid, post_poisson(counts, rate_grid))\n",
+    "plt.xlabel(r'$\\lambda$')\n",
+    "plt.ylabel(r'${\\rm P}(\\lambda)$')"
    ]
   },
   {
@@ -116,9 +116,9 @@
     "measurements = np.array([4.49, 5.15, 5.26 , 5.90, 4.86])\n",
     "error = 0.5\n",
     "weight_grid = np.linspace(3.5, 6.5, 100)\n",
-    "mp.plot(weight_grid, post_gaussian(measurements, error, weight_grid))\n",
-    "mp.xlabel(r'$w$')\n",
-    "mp.ylabel(r'${\\rm P}(w)$')"
+    "plt.plot(weight_grid, post_gaussian(measurements, error, weight_grid))\n",
+    "plt.xlabel(r'$w$')\n",
+    "plt.ylabel(r'${\\rm P}(w)$')"
    ]
   },
   {
@@ -148,9 +148,9 @@
     "\n",
     "error_grid = np.linspace(0.1, 1.2, 101)\n",
     "post = post_gaussian_mu_sig(measurements, weight_grid, error_grid)\n",
-    "mp.contour(weight_grid, error_grid, post.T, colors='k')\n",
-    "mp.xlabel(r'$w$')\n",
-    "mp.ylabel(r'$\\sigma$')"
+    "plt.contour(weight_grid, error_grid, post.T, colors='k')\n",
+    "plt.xlabel(r'$w$')\n",
+    "plt.ylabel(r'$\\sigma$')"
    ]
   },
   {
@@ -168,11 +168,11 @@
    "source": [
     "post_weight = np.sum(post, axis=1)\n",
     "post_weight_fixed_var = post_gaussian(measurements, error, weight_grid)\n",
-    "mp.plot(weight_grid, post_weight / np.sum(post_weight), label='marg $\\sigma$')\n",
-    "mp.plot(weight_grid, post_weight_fixed_var / np.sum(post_weight_fixed_var), label='fixed $\\sigma$')\n",
-    "mp.xlabel(r'$w$')\n",
-    "mp.ylabel(r'${\\rm P}(w)$')\n",
-    "mp.legend(loc='upper left')"
+    "plt.plot(weight_grid, post_weight / np.sum(post_weight), label='marg $\\sigma$')\n",
+    "plt.plot(weight_grid, post_weight_fixed_var / np.sum(post_weight_fixed_var), label='fixed $\\sigma$')\n",
+    "plt.xlabel(r'$w$')\n",
+    "plt.ylabel(r'${\\rm P}(w)$')\n",
+    "plt.legend(loc='upper left')"
    ]
   },
   {

--- a/day3_bayes/ahw_intro_incomplete.ipynb
+++ b/day3_bayes/ahw_intro_incomplete.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "import numpy as np\n",
     "import numpy.random as npr\n",
-    "import matplotlib.pyplot as mp\n",
+    "import matplotlib.pyplot as plt\n",
     "import scipy.stats as sps\n",
     "%matplotlib inline"
    ]
@@ -58,9 +58,9 @@
     "    return theta ** k * (1.0 - theta) ** (n - k)\n",
     "\n",
     "theta_grid = np.linspace(0.0, 1.0, 100)\n",
-    "mp.plot(theta_grid, post_binomial(10, 3, theta_grid))\n",
-    "mp.xlabel(r'$\\theta$')\n",
-    "mp.ylabel(r'${\\rm P}(\\theta)$')"
+    "plt.plot(theta_grid, post_binomial(10, 3, theta_grid))\n",
+    "plt.xlabel(r'$\\theta$')\n",
+    "plt.ylabel(r'${\\rm P}(\\theta)$')"
    ]
   },
   {
@@ -84,9 +84,9 @@
     "\n",
     "counts = np.array([4, 0, 3, 2, 4, 2, 3])\n",
     "rate_grid = np.linspace(0.0, 10.0, 100)\n",
-    "mp.plot(rate_grid, post_poisson(counts, rate_grid))\n",
-    "mp.xlabel(r'$\\lambda$')\n",
-    "mp.ylabel(r'${\\rm P}(\\lambda)$')"
+    "plt.plot(rate_grid, post_poisson(counts, rate_grid))\n",
+    "plt.xlabel(r'$\\lambda$')\n",
+    "plt.ylabel(r'${\\rm P}(\\lambda)$')"
    ]
   },
   {
@@ -115,9 +115,9 @@
     "measurements = np.array([4.49, 5.15, 5.26 , 5.90, 4.86])\n",
     "error = 0.5\n",
     "weight_grid = np.linspace(3.5, 6.5, 100)\n",
-    "mp.plot(weight_grid, post_gaussian(measurements, error, weight_grid))\n",
-    "mp.xlabel(r'$w$')\n",
-    "mp.ylabel(r'${\\rm P}(w)$')"
+    "plt.plot(weight_grid, post_gaussian(measurements, error, weight_grid))\n",
+    "plt.xlabel(r'$w$')\n",
+    "plt.ylabel(r'${\\rm P}(w)$')"
    ]
   },
   {
@@ -145,9 +145,9 @@
     "\n",
     "error_grid = np.linspace(0.1, 1.2, 101)\n",
     "post = post_gaussian_mu_sig(measurements, weight_grid, error_grid)\n",
-    "mp.contour(weight_grid, error_grid, post.T, colors='k')\n",
-    "mp.xlabel(r'$w$')\n",
-    "mp.ylabel(r'$\\sigma$')"
+    "plt.contour(weight_grid, error_grid, post.T, colors='k')\n",
+    "plt.xlabel(r'$w$')\n",
+    "plt.ylabel(r'$\\sigma$')"
    ]
   },
   {
@@ -165,11 +165,11 @@
    "source": [
     "post_weight = # ???\n",
     "post_weight_fixed_var = post_gaussian(measurements, error, weight_grid)\n",
-    "mp.plot(weight_grid, post_weight / np.sum(post_weight), label='marg $\\sigma$')\n",
-    "mp.plot(weight_grid, post_weight_fixed_var / np.sum(post_weight_fixed_var), label='fixed $\\sigma$')\n",
-    "mp.xlabel(r'$w$')\n",
-    "mp.ylabel(r'${\\rm P}(w)$')\n",
-    "mp.legend(loc='upper left')"
+    "plt.plot(weight_grid, post_weight / np.sum(post_weight), label='marg $\\sigma$')\n",
+    "plt.plot(weight_grid, post_weight_fixed_var / np.sum(post_weight_fixed_var), label='fixed $\\sigma$')\n",
+    "plt.xlabel(r'$w$')\n",
+    "plt.ylabel(r'${\\rm P}(w)$')\n",
+    "plt.legend(loc='upper left')"
    ]
   },
   {


### PR DESCRIPTION
This PR makes the minor suggestion of changing the pyplot imports in the day3 bayes exercises to use `plt` as the short form of `pyplot` instead of  of `mp` - this is the traditional convention the matplotlib team generally recommends.